### PR TITLE
Add modular PyQt5 Pluto+ SDR control application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# SDR-PLUTO-
+# Pluto+ Control Center
+
+A modular PyQt5 application for controlling an Analog Devices Pluto+ SDR with two RX and two TX channels. The application demonstrates a layered architecture with a device controller, signal-processing utilities, and a GUI built with PyQt5 and Matplotlib.
+
+## Features
+
+- Automatic IIO context discovery with preference for USB devices.
+- Spectrum analyzer with FFT, averaging, and peak readouts.
+- Dual-channel transmission control with waveform presets and power estimation.
+- Global configuration tab for AGC, buffer sizes, and LO synchronization.
+- JSON profile management for saving and loading presets.
+- Integrated log console for diagnostics.
+
+## Getting Started
+
+```bash
+pip install -r requirements.txt  # ensure PyQt5, matplotlib, numpy, pyadi-iio
+python -m sdr_pluto_app.main
+```
+
+When no hardware is available the application transparently falls back to a simulation mode so the GUI can be explored without a connected device.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+PyQt5
+matplotlib
+numpy
+pyadi-iio

--- a/sdr_pluto_app/__init__.py
+++ b/sdr_pluto_app/__init__.py
@@ -1,0 +1,17 @@
+"""Pluto+ SDR control center package."""
+
+from .device_controller import DeviceController, DeviceInfo, RXSettings, TXSettings
+from .gui import MainWindow, run_app
+from .signal_processing import compute_psd, estimate_power_dbfs, window_samples
+
+__all__ = [
+    "DeviceController",
+    "DeviceInfo",
+    "RXSettings",
+    "TXSettings",
+    "MainWindow",
+    "run_app",
+    "compute_psd",
+    "estimate_power_dbfs",
+    "window_samples",
+]

--- a/sdr_pluto_app/device_controller.py
+++ b/sdr_pluto_app/device_controller.py
@@ -1,0 +1,397 @@
+"""Device controller for Pluto+ SDR.
+
+This module provides a thread-safe wrapper around ``adi.Pluto`` that handles
+context discovery, RX streaming, TX waveform control, and shared device
+configuration. The controller exposes a callback-based API so that GUI or other
+clients can react to asynchronous events without directly depending on Qt.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from importlib import import_module, util
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+adi_spec = util.find_spec("adi")
+adi = import_module("adi") if adi_spec is not None else None  # type: ignore
+
+iio_spec = util.find_spec("iio")
+iio = import_module("iio") if iio_spec is not None else None  # type: ignore
+
+import numpy as np
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DeviceInfo:
+    """Collection of metadata about the connected SDR."""
+
+    name: str = "Unknown"
+    uri: str = ""
+    driver: str = ""
+    firmware: str = ""
+
+
+@dataclass
+class RXSettings:
+    """Runtime configuration for a single RX channel."""
+
+    channel: int = 0
+    center_frequency: float = 2.4e9
+    sample_rate: float = 20e6
+    rf_bandwidth: float = 20e6
+    fft_size: int = 4096
+    averaging: int = 1
+    gain: float = 0.0
+    agc_enabled: bool = True
+    buffer_size: int = 4096
+
+
+@dataclass
+class TXSettings:
+    """Runtime configuration for a single TX channel."""
+
+    channel: int = 0
+    center_frequency: float = 2.4e9
+    sample_rate: float = 20e6
+    rf_bandwidth: float = 20e6
+    hardware_gain: float = -10.0
+    baseband_amplitude: float = 0.5
+    waveform: str = "single-tone"
+    cyclic: bool = True
+    buffer_size: int = 4096
+
+
+class PlutoConnectionError(RuntimeError):
+    """Raised when a connection to the Pluto+ device cannot be established."""
+
+
+class DeviceController:
+    """Thread-safe controller that manages a Pluto+ SDR instance.
+
+    Parameters
+    ----------
+    rx_callback:
+        Optional callable that receives RX baseband samples as a NumPy array
+        along with a monotonic timestamp whenever new data is captured.
+    simulate:
+        When ``True`` a mock device is created to ease development or unit
+        testing on machines without access to real hardware.
+    """
+
+    RXCallback = Callable[[np.ndarray, float, RXSettings], None]
+
+    def __init__(
+        self,
+        rx_callback: Optional[RXCallback] = None,
+        *,
+        simulate: bool = False,
+    ) -> None:
+        self._rx_callback = rx_callback
+        self._simulate = simulate or adi is None
+        self._device: Optional["adi.Pluto"] = None  # type: ignore[name-defined]
+        self._rx_thread: Optional[threading.Thread] = None
+        self._rx_stop = threading.Event()
+        self._lock = threading.RLock()
+        self._rx_settings = RXSettings()
+        self._tx_settings: Dict[int, TXSettings] = {
+            0: TXSettings(channel=0),
+            1: TXSettings(channel=1),
+        }
+        self._connected = False
+        self._device_info = DeviceInfo()
+
+    # ------------------------------------------------------------------
+    # Connection handling
+    # ------------------------------------------------------------------
+    def discover_contexts(self) -> List[str]:
+        """Discover available IIO contexts.
+
+        The function prefers USB URIs followed by IP-based URIs. When libiio is
+        unavailable, a default list containing only ``"local"`` is returned.
+        """
+
+        usb_contexts: List[str] = []
+        ip_contexts: List[str] = []
+        if iio is None:
+            logger.warning("libiio not available; falling back to local context")
+            return ["local"]
+
+        try:
+            contexts = getattr(iio, "scan_contexts", None)
+            if contexts is None:
+                raise AttributeError("scan_contexts not available")
+            for uri, desc in contexts().items():  # type: ignore[call-arg]
+                uri = str(uri)
+                if uri.startswith("usb"):
+                    usb_contexts.append(uri)
+                elif uri.startswith("ip"):
+                    ip_contexts.append(uri)
+                else:
+                    ip_contexts.append(uri)
+        except Exception as exc:  # pragma: no cover - discovery failure
+            logger.error("Unable to scan IIO contexts: %s", exc)
+
+        ordered = usb_contexts + ip_contexts
+        if not ordered:
+            ordered.append("local")
+        return ordered
+
+    def connect(self) -> None:
+        """Attempt to connect to the first available context."""
+
+        with self._lock:
+            if self._connected:
+                return
+
+            if self._simulate:
+                logger.info("Starting device controller in simulation mode")
+                self._device_info = DeviceInfo(name="Simulated Pluto+", uri="sim")
+                self._connected = True
+                return
+
+            if adi is None:  # pragma: no cover - already covered by simulate flag
+                raise PlutoConnectionError("pyadi-iio is not available")
+
+            for uri in self.discover_contexts():
+                try:
+                    logger.info("Attempting to connect to Pluto+ at %s", uri)
+                    device = adi.Pluto(uri=uri)
+                    self._device = device
+                    self._connected = True
+                    self._device_info = DeviceInfo(
+                        name=getattr(device, "name", "Pluto"),
+                        uri=uri,
+                        driver=str(getattr(device, "context", "")),
+                        firmware=str(getattr(device, "rx_buffer_size", "")),
+                    )
+                    logger.info("Connected to Pluto+ at %s", uri)
+                    return
+                except Exception as exc:  # pragma: no cover - hardware specific
+                    logger.error("Failed to connect to %s: %s", uri, exc)
+
+            raise PlutoConnectionError("Unable to connect to any Pluto+ device")
+
+    def disconnect(self) -> None:
+        """Disconnect from the device and release all resources."""
+
+        with self._lock:
+            self.stop_rx()
+            if not self._connected:
+                return
+            self._device = None
+            self._connected = False
+            logger.info("Disconnected from Pluto+")
+
+    # ------------------------------------------------------------------
+    # RX control
+    # ------------------------------------------------------------------
+    def configure_rx(self, settings: RXSettings) -> None:
+        """Update the configuration for the RX path."""
+
+        with self._lock:
+            self._rx_settings = settings
+            if self._device is not None:
+                self._apply_rx_settings()
+
+    def _apply_rx_settings(self) -> None:
+        if self._device is None:  # pragma: no cover - simulation path
+            return
+        device = self._device
+        device.rx_lo = int(self._rx_settings.center_frequency)
+        device.sample_rate = int(self._rx_settings.sample_rate)
+        device.rx_rf_bandwidth = int(self._rx_settings.rf_bandwidth)
+        device.gain_control_mode = "slow_attack" if self._rx_settings.agc_enabled else "manual"
+        if not self._rx_settings.agc_enabled:
+            device.rx_hardwaregain = float(self._rx_settings.gain)
+        device.rx_buffer_size = int(self._rx_settings.buffer_size)
+
+    def start_rx(self) -> None:
+        """Start the RX worker thread if it is not already running."""
+
+        with self._lock:
+            if self._rx_thread and self._rx_thread.is_alive():
+                return
+            self._rx_stop.clear()
+            self._rx_thread = threading.Thread(target=self._rx_worker, daemon=True)
+            self._rx_thread.start()
+
+    def stop_rx(self) -> None:
+        """Stop the RX worker thread."""
+
+        with self._lock:
+            self._rx_stop.set()
+            if self._rx_thread and self._rx_thread.is_alive():
+                self._rx_thread.join(timeout=1.0)
+            self._rx_thread = None
+
+    def _rx_worker(self) -> None:
+        logger.debug("RX worker started")
+        while not self._rx_stop.is_set():
+            try:
+                samples = self._read_rx_samples()
+            except Exception as exc:  # pragma: no cover - runtime failure
+                logger.exception("RX worker error: %s", exc)
+                time.sleep(0.25)
+                continue
+
+            if samples is None or samples.size == 0:
+                time.sleep(0.01)
+                continue
+
+            if self._rx_callback:
+                timestamp = time.monotonic()
+                try:
+                    self._rx_callback(samples, timestamp, self._rx_settings)
+                except Exception:  # pragma: no cover - consumer failure
+                    logger.exception("RX callback raised an exception")
+
+        logger.debug("RX worker stopped")
+
+    def _read_rx_samples(self) -> Optional[np.ndarray]:
+        """Fetch baseband samples from the device or simulator."""
+
+        if self._simulate or self._device is None:
+            size = self._rx_settings.buffer_size
+            tone = np.exp(
+                1j
+                * 2
+                * np.pi
+                * np.linspace(0, 1, size, endpoint=False)
+                * (self._rx_settings.center_frequency % 1e6)
+                / 1e6
+            )
+            noise = 0.05 * (np.random.randn(size) + 1j * np.random.randn(size))
+            return (tone + noise).astype(np.complex64)
+
+        samples = self._device.rx()  # type: ignore[operator]
+        return np.asarray(samples)
+
+    # ------------------------------------------------------------------
+    # TX control
+    # ------------------------------------------------------------------
+    def configure_tx(self, settings: TXSettings) -> None:
+        """Update the configuration for a TX channel."""
+
+        with self._lock:
+            self._tx_settings[settings.channel] = settings
+            if self._device is not None:
+                self._apply_tx_settings(settings)
+
+    def _apply_tx_settings(self, settings: TXSettings) -> None:
+        if self._device is None:  # pragma: no cover - simulation path
+            return
+        device = self._device
+        device.tx_lo = int(settings.center_frequency)
+        device.tx_rf_bandwidth = int(settings.rf_bandwidth)
+        device.tx_hardwaregain = float(settings.hardware_gain)
+        device.tx_cyclic_buffer = bool(settings.cyclic)
+        device.tx_buffer_size = int(settings.buffer_size)
+
+    def stop_tx(self) -> None:
+        """Stop TX on all channels."""
+
+        if self._device is None or self._simulate:
+            return
+        self._device.tx_destroy_buffer()
+
+    def transmit_waveform(self, channel: int, waveform: np.ndarray) -> None:
+        """Load and transmit a baseband waveform on the given channel."""
+
+        with self._lock:
+            settings = self._tx_settings[channel]
+            if self._simulate or self._device is None:
+                logger.info(
+                    "Simulated transmission on channel %s with %d samples",
+                    channel,
+                    waveform.size,
+                )
+                return
+
+            self._apply_tx_settings(settings)
+            self._device.tx(waveform)  # type: ignore[operator]
+
+    # ------------------------------------------------------------------
+    # Shared configuration
+    # ------------------------------------------------------------------
+    def set_shared_setting(self, name: str, value: object) -> None:
+        """Set attributes that affect both RX and TX paths."""
+
+        with self._lock:
+            if self._device is None or self._simulate:
+                return
+            setattr(self._device, name, value)
+
+    # ------------------------------------------------------------------
+    # Device information & persistence
+    # ------------------------------------------------------------------
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return metadata about the current connection."""
+
+        return self._device_info
+
+    def export_settings(self) -> Dict[str, object]:
+        """Export RX, TX, and shared settings to a dictionary."""
+
+        with self._lock:
+            return {
+                "rx": self._rx_settings.__dict__,
+                "tx": {k: v.__dict__ for k, v in self._tx_settings.items()},
+                "device": self._device_info.__dict__,
+            }
+
+    def import_settings(self, data: Dict[str, object]) -> None:
+        """Load settings from a dictionary previously created by
+        :meth:`export_settings`.
+        """
+
+        rx = data.get("rx")
+        if isinstance(rx, dict):
+            self.configure_rx(RXSettings(**rx))
+
+        tx_block = data.get("tx")
+        if isinstance(tx_block, dict):
+            for channel, tx_data in tx_block.items():
+                if isinstance(tx_data, dict):
+                    settings = TXSettings(**tx_data)
+                    self.configure_tx(settings)
+
+    def save_profile(self, path: Path) -> None:
+        """Persist the current configuration to a JSON file."""
+
+        payload = self.export_settings()
+        path.write_text(json.dumps(payload, indent=2))
+
+    def load_profile(self, path: Path) -> None:
+        """Load a configuration profile from disk."""
+
+        data = json.loads(path.read_text())
+        if not isinstance(data, dict):
+            raise ValueError("Invalid profile structure")
+        self.import_settings(data)
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        """Cleanly release all resources."""
+
+        self.stop_rx()
+        self.stop_tx()
+        self.disconnect()
+
+
+__all__ = [
+    "DeviceController",
+    "RXSettings",
+    "TXSettings",
+    "DeviceInfo",
+    "PlutoConnectionError",
+]

--- a/sdr_pluto_app/gui.py
+++ b/sdr_pluto_app/gui.py
@@ -1,0 +1,451 @@
+"""PyQt5 GUI for controlling the Pluto+ SDR."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from PyQt5 import QtCore, QtGui, QtWidgets
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
+
+from .device_controller import DeviceController, RXSettings, TXSettings
+from .signal_processing import compute_psd, estimate_power_dbfs
+
+
+logger = logging.getLogger(__name__)
+
+
+class LogConsole(QtWidgets.QTextEdit):
+    """Simple console widget that mirrors the Python logging output."""
+
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setReadOnly(True)
+        self.setMaximumBlockCount(1000)
+
+    def write(self, message: str) -> None:
+        self.append(message.rstrip())
+
+    def flush(self) -> None:  # pragma: no cover - Qt callback
+        pass
+
+
+class MatplotlibCanvas(FigureCanvas):
+    """Matplotlib canvas with a single axes for spectrum plots."""
+
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        self._figure = Figure(figsize=(6, 4))
+        self._axes = self._figure.add_subplot(111)
+        super().__init__(self._figure)
+        self.setParent(parent)
+        self._axes.set_xlabel("Frequency (Hz)")
+        self._axes.set_ylabel("Amplitude (dBFS)")
+        self._axes.grid(True)
+        self._line = self._axes.plot([], [])[0]
+
+    def update_plot(self, freqs: np.ndarray, psd: np.ndarray) -> None:
+        self._line.set_data(freqs, psd)
+        self._axes.relim()
+        self._axes.autoscale_view()
+        self.draw_idle()
+
+
+class SpectrumTab(QtWidgets.QWidget):
+    """Spectrum analyzer tab handling RX visualization."""
+
+    def __init__(self, controller: DeviceController, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self._controller = controller
+        self._current_settings = RXSettings()
+        self._init_ui()
+
+    def _init_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+
+        form = QtWidgets.QFormLayout()
+        self.channel_combo = QtWidgets.QComboBox()
+        self.channel_combo.addItems(["RX1", "RX2"])
+        form.addRow("Channel", self.channel_combo)
+
+        self.center_freq = QtWidgets.QDoubleSpinBox()
+        self.center_freq.setSuffix(" MHz")
+        self.center_freq.setRange(50, 6000)
+        self.center_freq.setValue(self._current_settings.center_frequency / 1e6)
+        form.addRow("Center Frequency", self.center_freq)
+
+        self.sample_rate = QtWidgets.QDoubleSpinBox()
+        self.sample_rate.setSuffix(" MHz")
+        self.sample_rate.setRange(5, 50)
+        self.sample_rate.setValue(self._current_settings.sample_rate / 1e6)
+        form.addRow("Sample Rate", self.sample_rate)
+
+        self.bandwidth = QtWidgets.QDoubleSpinBox()
+        self.bandwidth.setSuffix(" MHz")
+        self.bandwidth.setRange(5, 50)
+        self.bandwidth.setValue(self._current_settings.rf_bandwidth / 1e6)
+        form.addRow("RF Bandwidth", self.bandwidth)
+
+        self.fft_size = QtWidgets.QSpinBox()
+        self.fft_size.setRange(256, 16384)
+        self.fft_size.setValue(self._current_settings.fft_size)
+        form.addRow("FFT Size", self.fft_size)
+
+        self.averaging = QtWidgets.QSpinBox()
+        self.averaging.setRange(1, 64)
+        self.averaging.setValue(self._current_settings.averaging)
+        form.addRow("Averaging", self.averaging)
+
+        layout.addLayout(form)
+
+        self.canvas = MatplotlibCanvas(self)
+        layout.addWidget(self.canvas)
+
+        controls = QtWidgets.QHBoxLayout()
+        self.start_button = QtWidgets.QPushButton("Start")
+        self.stop_button = QtWidgets.QPushButton("Stop")
+        controls.addWidget(self.start_button)
+        controls.addWidget(self.stop_button)
+        layout.addLayout(controls)
+
+        self.peak_label = QtWidgets.QLabel("Peak: -- dBFS")
+        layout.addWidget(self.peak_label)
+
+        self.start_button.clicked.connect(self.start_rx)
+        self.stop_button.clicked.connect(self.stop_rx)
+
+    def _collect_settings(self) -> RXSettings:
+        settings = RXSettings(
+            channel=self.channel_combo.currentIndex(),
+            center_frequency=self.center_freq.value() * 1e6,
+            sample_rate=self.sample_rate.value() * 1e6,
+            rf_bandwidth=self.bandwidth.value() * 1e6,
+            fft_size=self.fft_size.value(),
+            averaging=self.averaging.value(),
+        )
+        return settings
+
+    def start_rx(self) -> None:
+        self._current_settings = self._collect_settings()
+        self._controller.configure_rx(self._current_settings)
+        self._controller.start_rx()
+
+    def stop_rx(self) -> None:
+        self._controller.stop_rx()
+
+    def update_spectrum(self, samples: np.ndarray, timestamp: float, settings: RXSettings) -> None:
+        freqs, psd = compute_psd(
+            samples,
+            settings.sample_rate,
+            window="hann",
+            fft_size=settings.fft_size,
+            average=settings.averaging,
+        )
+        self.canvas.update_plot(freqs, psd)
+        peak = float(np.max(psd))
+        self.peak_label.setText(f"Peak: {peak:.1f} dBFS")
+
+
+class TransmissionTab(QtWidgets.QWidget):
+    """Transmission control tab."""
+
+    waveform_requested = QtCore.pyqtSignal(int, np.ndarray)
+
+    def __init__(self, controller: DeviceController, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self._controller = controller
+        self._settings = {
+            0: TXSettings(channel=0),
+            1: TXSettings(channel=1),
+        }
+        self._init_ui()
+
+    def _init_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+        self.tabs = QtWidgets.QTabWidget()
+        layout.addWidget(self.tabs)
+
+        for channel in (0, 1):
+            tab = QtWidgets.QWidget()
+            tab_layout = QtWidgets.QFormLayout(tab)
+
+            freq = QtWidgets.QDoubleSpinBox()
+            freq.setSuffix(" MHz")
+            freq.setRange(50, 6000)
+            freq.setValue(self._settings[channel].center_frequency / 1e6)
+            tab_layout.addRow("Center Frequency", freq)
+
+            sample = QtWidgets.QDoubleSpinBox()
+            sample.setSuffix(" MHz")
+            sample.setRange(5, 50)
+            sample.setValue(self._settings[channel].sample_rate / 1e6)
+            tab_layout.addRow("Sample Rate", sample)
+
+            bw = QtWidgets.QDoubleSpinBox()
+            bw.setSuffix(" MHz")
+            bw.setRange(5, 50)
+            bw.setValue(self._settings[channel].rf_bandwidth / 1e6)
+            tab_layout.addRow("RF Bandwidth", bw)
+
+            gain = QtWidgets.QDoubleSpinBox()
+            gain.setSuffix(" dB")
+            gain.setRange(-90, 0)
+            gain.setValue(self._settings[channel].hardware_gain)
+            tab_layout.addRow("Hardware Gain", gain)
+
+            amplitude = QtWidgets.QDoubleSpinBox()
+            amplitude.setRange(0.0, 1.0)
+            amplitude.setSingleStep(0.01)
+            amplitude.setValue(self._settings[channel].baseband_amplitude)
+            tab_layout.addRow("Baseband Amplitude", amplitude)
+
+            waveform = QtWidgets.QComboBox()
+            waveform.addItems(["AWGN", "single-tone", "multi-tone", "from-file"])
+            tab_layout.addRow("Waveform", waveform)
+
+            cyclic = QtWidgets.QCheckBox("Cyclic Buffer")
+            cyclic.setChecked(self._settings[channel].cyclic)
+            tab_layout.addRow("", cyclic)
+
+            buffer_size = QtWidgets.QSpinBox()
+            buffer_size.setRange(1024, 1 << 16)
+            buffer_size.setValue(self._settings[channel].buffer_size)
+            tab_layout.addRow("Buffer Size", buffer_size)
+
+            start_button = QtWidgets.QPushButton("Start TX")
+            stop_button = QtWidgets.QPushButton("Stop TX")
+            power_label = QtWidgets.QLabel("Power: -- dBFS")
+
+            tab_layout.addRow(start_button, stop_button)
+            tab_layout.addRow("TX Power", power_label)
+
+            self.tabs.addTab(tab, f"TX{channel + 1}")
+
+            start_button.clicked.connect(lambda _, ch=channel: self._start_tx(ch))
+            stop_button.clicked.connect(lambda _, ch=channel: self._controller.stop_tx())
+
+            # store references
+            tab.freq = freq  # type: ignore[attr-defined]
+            tab.sample = sample  # type: ignore[attr-defined]
+            tab.bw = bw  # type: ignore[attr-defined]
+            tab.gain = gain  # type: ignore[attr-defined]
+            tab.amplitude = amplitude  # type: ignore[attr-defined]
+            tab.waveform = waveform  # type: ignore[attr-defined]
+            tab.cyclic = cyclic  # type: ignore[attr-defined]
+            tab.buffer = buffer_size  # type: ignore[attr-defined]
+            tab.power = power_label  # type: ignore[attr-defined]
+
+        self.waveform_requested.connect(self._controller.transmit_waveform)
+
+    def _collect_settings(self, channel: int) -> TXSettings:
+        tab = self.tabs.widget(channel)
+        assert tab is not None
+        settings = TXSettings(
+            channel=channel,
+            center_frequency=tab.freq.value() * 1e6,
+            sample_rate=tab.sample.value() * 1e6,
+            rf_bandwidth=tab.bw.value() * 1e6,
+            hardware_gain=tab.gain.value(),
+            baseband_amplitude=tab.amplitude.value(),
+            waveform=tab.waveform.currentText(),
+            cyclic=tab.cyclic.isChecked(),
+            buffer_size=tab.buffer.value(),
+        )
+        return settings
+
+    def _generate_waveform(self, settings: TXSettings) -> np.ndarray:
+        samples = settings.buffer_size
+        t = np.arange(samples) / settings.sample_rate
+        if settings.waveform == "AWGN":
+            waveform = (
+                np.random.randn(samples) + 1j * np.random.randn(samples)
+            ) * settings.baseband_amplitude
+        elif settings.waveform == "multi-tone":
+            freqs = [0.05, 0.1, 0.15]
+            waveform = sum(
+                np.exp(2j * np.pi * f * t) for f in freqs
+            ) * settings.baseband_amplitude / len(freqs)
+        else:  # default single-tone
+            waveform = settings.baseband_amplitude * np.exp(2j * np.pi * 0.1 * t)
+        return waveform.astype(np.complex64)
+
+    def _start_tx(self, channel: int) -> None:
+        settings = self._collect_settings(channel)
+        self._controller.configure_tx(settings)
+        waveform = self._generate_waveform(settings)
+        power = estimate_power_dbfs(waveform)
+        tab = self.tabs.widget(channel)
+        if tab is not None:
+            tab.power.setText(f"Power: {power:.1f} dBFS")  # type: ignore[attr-defined]
+        self.waveform_requested.emit(channel, waveform)
+
+
+class ConfigTab(QtWidgets.QWidget):
+    """Shared device configuration tab."""
+
+    def __init__(self, controller: DeviceController, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self._controller = controller
+        self._init_ui()
+
+    def _init_ui(self) -> None:
+        layout = QtWidgets.QFormLayout(self)
+
+        self.agc = QtWidgets.QCheckBox("Enable AGC")
+        layout.addRow(self.agc)
+
+        self.dc_correction = QtWidgets.QCheckBox("DC Offset Correction")
+        layout.addRow(self.dc_correction)
+
+        self.lo_sync = QtWidgets.QCheckBox("LO Synchronization")
+        layout.addRow(self.lo_sync)
+
+        self.buffer_size = QtWidgets.QSpinBox()
+        self.buffer_size.setRange(1024, 1 << 16)
+        self.buffer_size.setValue(4096)
+        layout.addRow("Shared Buffer Size", self.buffer_size)
+
+        self.apply_button = QtWidgets.QPushButton("Apply")
+        layout.addRow(self.apply_button)
+
+        self.info_label = QtWidgets.QLabel("Device info not available")
+        self.info_label.setWordWrap(True)
+        layout.addRow("Device", self.info_label)
+
+        self.apply_button.clicked.connect(self.apply_settings)
+
+    def apply_settings(self) -> None:
+        settings = {
+            "rx_buffer_size": self.buffer_size.value(),
+            "tx_buffer_size": self.buffer_size.value(),
+            "dc_offset_tracking": int(self.dc_correction.isChecked()),
+            "quad_tracking_en": int(self.lo_sync.isChecked()),
+        }
+        for key, value in settings.items():
+            self._controller.set_shared_setting(key, value)
+        info = self._controller.device_info
+        self.info_label.setText(
+            f"Name: {info.name}\nURI: {info.uri}\nDriver: {info.driver}\nFirmware: {info.firmware}"
+        )
+
+
+class ProfilesTab(QtWidgets.QWidget):
+    """Manage user profiles for SDR settings."""
+
+    def __init__(self, controller: DeviceController, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self._controller = controller
+        self._init_ui()
+
+    def _init_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+        self.path_edit = QtWidgets.QLineEdit(str(Path.home() / "pluto_profile.json"))
+        layout.addWidget(self.path_edit)
+
+        buttons = QtWidgets.QHBoxLayout()
+        self.save_button = QtWidgets.QPushButton("Save Profile")
+        self.load_button = QtWidgets.QPushButton("Load Profile")
+        buttons.addWidget(self.save_button)
+        buttons.addWidget(self.load_button)
+        layout.addLayout(buttons)
+
+        self.save_button.clicked.connect(self.save_profile)
+        self.load_button.clicked.connect(self.load_profile)
+
+    def save_profile(self) -> None:
+        path = Path(self.path_edit.text())
+        try:
+            self._controller.save_profile(path)
+        except Exception as exc:
+            QtWidgets.QMessageBox.critical(self, "Save failed", str(exc))
+
+    def load_profile(self) -> None:
+        path = Path(self.path_edit.text())
+        try:
+            self._controller.load_profile(path)
+        except Exception as exc:
+            QtWidgets.QMessageBox.critical(self, "Load failed", str(exc))
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    """Main application window that combines all tabs."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Pluto+ Control Center")
+        self.resize(1200, 800)
+
+        self.log_console = LogConsole()
+        logging.getLogger().addHandler(self._create_handler())
+
+        self.controller = DeviceController(rx_callback=self._on_rx_samples)
+        try:
+            self.controller.connect()
+        except Exception as exc:
+            QtWidgets.QMessageBox.critical(self, "Connection error", str(exc))
+
+        self.spectrum_tab = SpectrumTab(self.controller)
+        self.tx_tab = TransmissionTab(self.controller)
+        self.config_tab = ConfigTab(self.controller)
+        self.profiles_tab = ProfilesTab(self.controller)
+
+        tabs = QtWidgets.QTabWidget()
+        tabs.addTab(self.spectrum_tab, "Spectrum Analyzer")
+        tabs.addTab(self.tx_tab, "Transmission")
+        tabs.addTab(self.config_tab, "Config")
+        tabs.addTab(self.profiles_tab, "Profiles")
+
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(central)
+        layout.addWidget(tabs)
+        layout.addWidget(self.log_console)
+        self.setCentralWidget(central)
+
+    def _create_handler(self) -> logging.Handler:
+        handler = logging.StreamHandler(self.log_console)
+        handler.setLevel(logging.INFO)
+        formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+        handler.setFormatter(formatter)
+        return handler
+
+    # ------------------------------------------------------------------
+    # RX callback entry point
+    # ------------------------------------------------------------------
+    @QtCore.pyqtSlot(np.ndarray, float, RXSettings)
+    def _on_rx_samples(self, samples: np.ndarray, timestamp: float, settings: RXSettings) -> None:
+        QtCore.QMetaObject.invokeMethod(
+            self,
+            "_update_spectrum_ui",
+            QtCore.Qt.QueuedConnection,
+            QtCore.Q_ARG(object, samples),
+            QtCore.Q_ARG(float, timestamp),
+            QtCore.Q_ARG(object, settings),
+        )
+
+    @QtCore.pyqtSlot(object, float, object)
+    def _update_spectrum_ui(self, samples: np.ndarray, timestamp: float, settings: RXSettings) -> None:
+        self.spectrum_tab.update_spectrum(samples, timestamp, settings)
+
+    def closeEvent(self, event: QtGui.QCloseEvent) -> None:  # pragma: no cover - Qt
+        try:
+            self.controller.close()
+        finally:
+            super().closeEvent(event)
+
+
+def run_app() -> None:
+    """Entry point for launching the PyQt5 application."""
+
+    import sys
+
+    app = QtWidgets.QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec_())
+
+
+__all__ = [
+    "MainWindow",
+    "run_app",
+]

--- a/sdr_pluto_app/main.py
+++ b/sdr_pluto_app/main.py
@@ -1,0 +1,14 @@
+"""Executable entry point for the Pluto+ SDR GUI."""
+from __future__ import annotations
+
+from .gui import run_app
+
+
+def main() -> None:
+    """Run the Pluto+ SDR control center."""
+
+    run_app()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    main()

--- a/sdr_pluto_app/signal_processing.py
+++ b/sdr_pluto_app/signal_processing.py
@@ -1,0 +1,74 @@
+"""Signal processing helpers for the Pluto+ SDR GUI."""
+from __future__ import annotations
+
+import numpy as np
+from typing import Tuple
+
+
+WINDOWS = {
+    "hann": np.hanning,
+    "hamming": np.hamming,
+    "blackman": np.blackman,
+    "rect": lambda n: np.ones(n, dtype=float),
+}
+
+
+def window_samples(samples: np.ndarray, window: str) -> np.ndarray:
+    """Apply a named window function to the provided samples.
+
+    Parameters
+    ----------
+    samples:
+        Complex baseband samples.
+    window:
+        Name of the window function in :data:`WINDOWS`.
+    """
+
+    func = WINDOWS.get(window, WINDOWS["hann"])
+    taps = func(len(samples))
+    return samples * taps
+
+
+def compute_psd(
+    samples: np.ndarray,
+    sample_rate: float,
+    *,
+    window: str = "hann",
+    fft_size: int = 4096,
+    average: int = 1,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Compute the power spectral density of the provided samples.
+
+    Returns frequency bins (Hz) and magnitudes (dBFS).
+    """
+
+    if samples.size < fft_size:
+        samples = np.pad(samples, (0, fft_size - samples.size), mode="constant")
+
+    segments = max(1, min(average, samples.size // fft_size))
+    spectra = []
+    for idx in range(segments):
+        start = idx * fft_size
+        end = start + fft_size
+        windowed = window_samples(samples[start:end], window)
+        fft = np.fft.fftshift(np.fft.fft(windowed))
+        spectra.append(np.abs(fft))
+
+    if not spectra:
+        windowed = window_samples(samples[:fft_size], window)
+        spectra.append(np.abs(np.fft.fftshift(np.fft.fft(windowed))))
+
+    avg_fft = np.mean(spectra, axis=0)
+    magnitude = 20 * np.log10(np.maximum(avg_fft, 1e-12))
+    freqs = np.fft.fftshift(np.fft.fftfreq(fft_size, d=1.0 / sample_rate))
+    return freqs, magnitude
+
+
+def estimate_power_dbfs(samples: np.ndarray) -> float:
+    """Estimate the TX power in dBFS from baseband samples."""
+
+    rms = np.sqrt(np.mean(np.abs(samples) ** 2))
+    return 20 * np.log10(max(rms, 1e-12))
+
+
+__all__ = ["WINDOWS", "window_samples", "compute_psd", "estimate_power_dbfs"]


### PR DESCRIPTION
## Summary
- add a layered Pluto+ SDR control package with device controller, signal processing, and GUI modules
- provide PyQt5 interface featuring spectrum analyzer, dual-channel transmission control, configuration, and profile management tabs
- document usage and dependencies while enabling profile persistence and logging support

## Testing
- python -m compileall sdr_pluto_app

------
https://chatgpt.com/codex/tasks/task_e_68de60638f0c8324b2431ba917a59e4e